### PR TITLE
Use PHPDoc to typehint VultrClient properties

### DIFF
--- a/src/VultrClient.php
+++ b/src/VultrClient.php
@@ -13,6 +13,30 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Throwable;
 use Vultr\VultrPhp\Services;
 
+/**
+ * @property-read Services\Account\AccountService $account
+ * @property-read Services\Applications\ApplicationService $applications
+ * @property-read Services\Backups\BackupService $backups
+ * @property-read Services\BareMetal\BareMetalService $baremetal
+ * @property-read Services\Billing\BillingService $billing
+ * @property-read Services\BlockStorage\BlockStorageService $blockstorage
+ * @property-read Services\DNS\DNSService $dns
+ * @property-read Services\Firewall\FirewallService $firewall
+ * @property-read Services\Instances\InstanceService $instances
+ * @property-read Services\ISO\ISOService $iso
+ * @property-read Services\Kubernetes\KubernetesService $kubernetes
+ * @property-read Services\LoadBalancers\LoadBalancerService $loadbalancers
+ * @property-read Services\ObjectStorage\ObjectStorageService $objectstorage
+ * @property-read Services\OperatingSystems\OperatingSystemService $operating_system
+ * @property-read Services\Plans\PlanService $plans
+ * @property-read Services\ReservedIP\ReservedIPService $reserved_ip
+ * @property-read Services\Regions\RegionService $regions
+ * @property-read Services\Snapshots\SnapshotService $snapshots
+ * @property-read Services\SSHKeys\SSHKeyService $ssh_keys
+ * @property-read Services\StartupScripts\StartupScriptService $startup_scripts
+ * @property-read Services\Users\UserService $users
+ * @property-read Services\VPC\VPCService $vpc
+ */
 class VultrClient
 {
 	private VultrClientHandler $client;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Adds PHPDoc property typehints on the VultrClient class.  This doesn't affect any behavior but helps the IDE typehint what properties are available.

As a side note - if you required ^8.1 instead of ^8.0 you could use public readonly properties to accomplish the task a little cleaner/more type-safe (4ac77f8ff8f3ac78b280c53f6c33535104a10c56 - although not proposing this now as readonly properties were only added in 8.1)

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
